### PR TITLE
Avoid 'file exists' error if file has been previously downloaded

### DIFF
--- a/AFDownloadRequestOperation.h
+++ b/AFDownloadRequestOperation.h
@@ -39,6 +39,12 @@
  */
 @property (strong) NSString *targetPath;
 
+/**
+ A Boolean value that indicates if we should allow a downloaded file to overwrite
+ a previously downloaded file of the same name. Default is `NO`.
+ */
+@property (assign) BOOL shouldOverwrite;
+
 /** 
  A Boolean value that indicates if we should try to resume the download. Defaults is `YES`.
 

--- a/AFDownloadRequestOperation.m
+++ b/AFDownloadRequestOperation.m
@@ -176,7 +176,9 @@ typedef void (^AFURLConnectionProgressiveOperationProgressBlock)(NSInteger bytes
             // move file to final position and capture error
             @synchronized(self) {
                 NSFileManager *fileManager = [NSFileManager new];
-                [fileManager removeItemAtPath:_targetPath error:NULL]; // avoid "File exists" error
+                if (self.shouldOverwrite) {
+                    [fileManager removeItemAtPath:_targetPath error:NULL]; // avoid "File exists" error
+                }
                 [fileManager moveItemAtPath:[self tempPath] toPath:_targetPath error:&localError];
                 if (localError) {
                     _fileError = localError;


### PR DESCRIPTION
I ran into a problem that after a file downloaded, the renaming/moving from the cache to the final filename was failing with a with a "file exists" error if the file had previously been downloaded.

Now, the caller could remove the file before the download is started, but since AFDownloadRequestOperation knows the eventual filename (the caller just has a URL) and is responsible for the moving, I think it makes sense to remove the file before attempting the move and thus avoiding an error.
