### PR TITLE
Fixed HTTP 416 error, the starting-value beyond the range!

### DIFF
--- a/AFDownloadRequestOperation.m
+++ b/AFDownloadRequestOperation.m
@@ -93,7 +93,8 @@ typedef void (^AFURLConnectionProgressiveOperationProgressBlock)(NSInteger bytes
     BOOL isResuming = NO;
     if (self.shouldResume) {
         unsigned long long downloadedBytes = [self fileSizeForPath:[self tempPath]];
-        if (downloadedBytes > 0) {
+        if (downloadedBytes > 1) {
+            downloadedBytes--;
             NSMutableURLRequest *mutableURLRequest = [self.request mutableCopy];
             NSString *requestRange = [NSString stringWithFormat:@"bytes=%llu-", downloadedBytes];
             [mutableURLRequest setValue:requestRange forHTTPHeaderField:@"Range"];
@@ -217,7 +218,7 @@ typedef void (^AFURLConnectionProgressiveOperationProgressBlock)(NSInteger bytes
             NSArray *bytes = [contentRange componentsSeparatedByCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@" -/"]];
             if ([bytes count] == 4) {
                 fileOffset = [bytes[1] longLongValue];
-                totalContentLength = [bytes[2] longLongValue]; // if this is *, it's converted to 0
+                totalContentLength = [bytes[3] longLongValue]; // if this is *, it's converted to 0
             }
         }
     }


### PR DESCRIPTION
Fixed HTTP 416 error, the starting-value beyond the range!

If the the current download-request's data has been fully downloaded, but other causes of the Operation failed (such as the inability of the incomplete temporary file copied to the target location), next, retry this download-request, the starting-value (equal to the incomplete temporary file size) will lead to out of Range!

e.g. 
Response: "Range 0-50/51" -- 51 bytes downloaded
Retry Request: "Range 51-  " -- out of range
