### PR TITLE
Added reference to AFDownloadRequestOperation in progressiveDownloadProgressBlock

### DIFF
--- a/AFDownloadRequestOperation.h
+++ b/AFDownloadRequestOperation.h
@@ -101,6 +101,6 @@
  
  @see setDownloadProgressBlock
  */
-- (void)setProgressiveDownloadProgressBlock:(void (^)(NSInteger bytesRead, long long totalBytesRead, long long totalBytesExpected, long long totalBytesReadForFile, long long totalBytesExpectedToReadForFile))block;
+- (void)setProgressiveDownloadProgressBlock:(void (^)(AFDownloadRequestOperation *operation, NSInteger bytesRead, long long totalBytesRead, long long totalBytesExpected, long long totalBytesReadForFile, long long totalBytesExpectedToReadForFile))block;
 
 @end

--- a/AFDownloadRequestOperation.m
+++ b/AFDownloadRequestOperation.m
@@ -35,7 +35,7 @@
 @property (readonly, nonatomic, assign) long long totalBytesRead;
 @end
 
-typedef void (^AFURLConnectionProgressiveOperationProgressBlock)(NSInteger bytes, long long totalBytes, long long totalBytesExpected, long long totalBytesReadForFile, long long totalBytesExpectedToReadForFile);
+typedef void (^AFURLConnectionProgressiveOperationProgressBlock)(AFDownloadRequestOperation *operation, NSInteger bytes, long long totalBytes, long long totalBytesExpected, long long totalBytesReadForFile, long long totalBytesExpectedToReadForFile);
 
 @interface AFDownloadRequestOperation() {
     NSError *_fileError;
@@ -131,7 +131,7 @@ typedef void (^AFURLConnectionProgressiveOperationProgressBlock)(NSInteger bytes
 }
 
 
-- (void)setProgressiveDownloadProgressBlock:(void (^)(NSInteger bytesRead, long long totalBytesRead, long long totalBytesExpected, long long totalBytesReadForFile, long long totalBytesExpectedToReadForFile))block {
+- (void)setProgressiveDownloadProgressBlock:(void (^)(AFDownloadRequestOperation *operation, NSInteger bytesRead, long long totalBytesRead, long long totalBytesExpected, long long totalBytesReadForFile, long long totalBytesExpectedToReadForFile))block {
     self.progressiveDownloadProgress = block;
 }
 
@@ -246,7 +246,7 @@ typedef void (^AFURLConnectionProgressiveOperationProgressBlock)(NSInteger bytes
 
     if (self.progressiveDownloadProgress) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            self.progressiveDownloadProgress((long long)[data length], self.totalBytesRead, self.response.expectedContentLength,self.totalBytesReadPerDownload + self.offsetContentLength, self.totalContentLength);
+            self.progressiveDownloadProgress(self,(long long)[data length], self.totalBytesRead, self.response.expectedContentLength,self.totalBytesReadPerDownload + self.offsetContentLength, self.totalContentLength);
         });
     }
 }


### PR DESCRIPTION
Hi,

I have added a reference to the operation object in the progressiveDownloadProgressBlock.
This is to fix the self capturing issue if the operation object is used inside the block.

Thanks.
