### PR TITLE
update podspec to new version

### DIFF
--- a/AFDownloadRequestOperation.podspec
+++ b/AFDownloadRequestOperation.podspec
@@ -1,13 +1,14 @@
 Pod::Spec.new do |s|
   s.name           = 'AFDownloadRequestOperation'
-  s.version        = '0.0.1'
+  s.version        = '0.0.2'
   s.summary        = "A progressive download operation for AFNetworking."
   s.homepage       = "https://github.com/steipete/AFDownloadRequestOperation"
   s.author         = { 'Peter Steinberger' => 'steipete@gmail.com' }
-  s.source         = { :git => 'https://github.com/steipete/AFDownloadRequestOperation.git', :commit => '2d7672ba74f1eae1fa2f8bd45525df1f5be81e40' }
+  s.source         = { :git => 'https://github.com/steipete/AFDownloadRequestOperation.git', :tag => s.version.to_s }
   s.platform       = :ios, '5.0'
   s.requires_arc   = true
   s.source_files   = '*.{h,m}'
   s.license        = 'MIT'
-  s.dependency 'AFNetworking', :head
+  s.dependency 'AFNetworking', '>=1.1'
 end
+


### PR DESCRIPTION
The public API has changed since last commit, there should be a new version for cocoa pods. I change the dependency to 1.1 because :head is not public supported and won't work on future versions. The version 1.1 is what the README says that the repo has been tested against.

A new tag '0.0.2' is also required.
