### PR TITLE
Progressive download callback queue customization

### DIFF
--- a/AFDownloadRequestOperation.h
+++ b/AFDownloadRequestOperation.h
@@ -69,6 +69,11 @@
  */
 @property (assign, readonly) long long offsetContentLength;
 
+/**
+ The callback dispatch queue on progressive download. If `NULL` (default), the main queue is used.
+ */
+@property (nonatomic, assign) dispatch_queue_t progressiveDownloadCallbackQueue;
+
 ///----------------------------------
 /// @name Creating Request Operations
 ///----------------------------------


### PR DESCRIPTION
calling progressive download callback on the main queue leads to UI lags and loose overall application performance. So there should be ability to customize callback queue
