### PR TITLE
Avoid errors when resuming a fully downloaded file

### DIFF
--- a/AFDownloadRequestOperation.m
+++ b/AFDownloadRequestOperation.m
@@ -150,6 +150,15 @@ typedef void (^AFURLConnectionProgressiveOperationProgressBlock)(AFDownloadReque
     return fileSize;
 }
 
+#pragma mark - AFHTTPRequestOperation
+
++ (NSIndexSet *)acceptableStatusCodes {
+	NSMutableIndexSet *acceptableStatusCodes = [NSMutableIndexSet indexSetWithIndexesInRange:NSMakeRange(200, 100)];
+	[acceptableStatusCodes addIndex:416];
+	
+	return acceptableStatusCodes;
+}
+
 #pragma mark - AFURLRequestOperation
 
 - (void)pause {


### PR DESCRIPTION
If the offset of the Range header is equal to the content length (as is the case for a fully downloaded file), a 416 Requested Range Not Satisfiable status code will be returned. We need to add this status code to the index set of acceptable status codes.
