### PR TITLE
Make sure we don't write to output stream if any error occurs.

### DIFF
--- a/AFDownloadRequestOperation.m
+++ b/AFDownloadRequestOperation.m
@@ -277,6 +277,9 @@ typedef void (^AFURLConnectionProgressiveOperationProgressBlock)(AFDownloadReque
 }
 
 - (void)connection:(NSURLConnection *)connection didReceiveData:(NSData *)data  {
+    if (![self hasAcceptableStatusCode] || ![self hasAcceptableContentType])
+        return; // don't write to output stream if any error occurs
+
     [super connection:connection didReceiveData:data];
 
     // track custom bytes read because totalBytesRead persists between pause/resume.


### PR DESCRIPTION
Hi, @steipete. I found a problem in AFDownloadRequestOperation.

If remote server returns an error e.g. 404 with a error page, the content of that page will be written to the output stream. When resuming a partial downloading, this kind of error corrupts the file.

IMO, if the intention is to download a file, saving an error page to the file system would be useless anyway. So I fixed it by check the status code & content type before writing anything to the stream.
