### PR TITLE
Prevent pulling in AFNetworking 2.0

### DIFF
--- a/AFDownloadRequestOperation.podspec
+++ b/AFDownloadRequestOperation.podspec
@@ -9,6 +9,6 @@ Pod::Spec.new do |s|
   s.requires_arc   = true
   s.source_files   = '*.{h,m}'
   s.license        = 'MIT'
-  s.dependency 'AFNetworking', '>=1.1'
+  s.dependency 'AFNetworking', '~> 1.1'
 end
 


### PR DESCRIPTION
Projects supporting anything lower than iOS 7 that also use AFDownloadRequestOperation will not be able to `pod install` because the dependency in the podspec jumps up to AFNetworking 2.0 beta (arguably a bug in CocoaPods, see [#1263](https://github.com/CocoaPods/CocoaPods/issues/1263)). 

This change allows the dependent version of AFNetworking to increment but keeps it below 2.0.
