### PR TITLE
Fixes issue #37

### DIFF
--- a/AFDownloadRequestOperation.m
+++ b/AFDownloadRequestOperation.m
@@ -288,6 +288,7 @@ typedef void (^AFURLConnectionProgressiveOperationProgressBlock)(AFDownloadReque
             [file closeFile];
         }
         self.outputStream = [NSOutputStream outputStreamToFileAtPath:temp append:isResuming];
+        [self.outputStream open];
     }
 }
 


### PR DESCRIPTION
This fixes issue #37 by truncating the cache file to the content offset returned by the server, and then creating a new output stream instance.
