### PR TITLE
move self.progressiveDownloadProgress check to dispatch_async block

### DIFF
--- a/AFDownloadRequestOperation.m
+++ b/AFDownloadRequestOperation.m
@@ -288,11 +288,11 @@ typedef void (^AFURLConnectionProgressiveOperationProgressBlock)(AFDownloadReque
     // track custom bytes read because totalBytesRead persists between pause/resume.
     self.totalBytesReadPerDownload += [data length];
 
-    if (self.progressiveDownloadProgress) {
-        dispatch_async(self.progressiveDownloadCallbackQueue ?: dispatch_get_main_queue(), ^{
+    dispatch_async(self.progressiveDownloadCallbackQueue ?: dispatch_get_main_queue(), ^{
+        if (self.progressiveDownloadProgress) {
             self.progressiveDownloadProgress(self,(NSInteger)[data length], self.totalBytesRead, self.response.expectedContentLength,self.totalBytesReadPerDownload + self.offsetContentLength, self.totalContentLength);
-        });
-    }
+        }
+    });
 }
 
 #pragma mark - Static


### PR DESCRIPTION
Before execute dispatch_async block, we checked self.progressiveDownloadProgress is nil.
But, although this object is not nil, inside dispatch_async block, this object can not be guaranteed nil or not.
So I changed nil check inside of dispatch_async block.
