### PR TITLE
Validating response

### DIFF
--- a/AFDownloadRequestOperation.m
+++ b/AFDownloadRequestOperation.m
@@ -199,7 +199,7 @@ typedef void (^AFURLConnectionProgressiveOperationProgressBlock)(AFDownloadReque
                 self.responseSerializationError = error;
             }
 			
-			if (!self.error) {
+            if (!self.error) {
                 NSError *localError = nil;
                 if ([self isCancelled]) {
                     // should we clean up? most likely we don't.


### PR DESCRIPTION
I'm using `AFDownloadRequestOperation` on my project, but when it receives 416 HTTP status (Requested Range Not Satisfiable), the success block is being called. So I created this fix: every time responseObject is accessed, it validates the response using the (default) `responseSerializer`, which checks acceptable HTTP status codes.

Adding to that, I removed `+ acceptableStatusCodes`  method that is not called on AFNetworking 2.0.

I hope this helps.
