### PR TITLE
Fixed potential nil data crash

### DIFF
--- a/AFDownloadRequestOperation.m
+++ b/AFDownloadRequestOperation.m
@@ -282,7 +282,7 @@ typedef void (^AFURLConnectionProgressiveOperationProgressBlock)(AFDownloadReque
 }
 
 - (void)connection:(NSURLConnection *)connection didReceiveData:(NSData *)data  {
-    if (![self.responseSerializer validateResponse:self.response data:nil error:NULL])
+    if (![self.responseSerializer validateResponse:self.response data:data ?: [NSData data] error:NULL])
         return; // don't write to output stream if any error occurs
 
     [super connection:connection didReceiveData:data];


### PR DESCRIPTION
When a response is received but no data, AFNetworking will crash in
- (BOOL)validateResponse:(NSHTTPURLResponse *)response
                  data:(NSData *)data
                 error:(NSError *__autoreleasing *)error;

due to the request validation not being nil safe on the data object.
