### PR TITLE
The temporary filename can be chosen

### DIFF
--- a/AFDownloadRequestOperation.h
+++ b/AFDownloadRequestOperation.h
@@ -88,6 +88,17 @@
  */
 - (id)initWithRequest:(NSURLRequest *)urlRequest targetPath:(NSString *)targetPath shouldResume:(BOOL)shouldResume;
 
+/**
+ Creates and returns an `AFDownloadRequestOperation`
+ @param urlRequest The request object to be loaded asynchronously during execution of the operation
+ @param fileIdentifier An unique file identifier to be used for the temporary filename, instead of calculating
+ 	 	it using the targetPath. Which prevents problems of the iOS supplied random container paths.
+ @param targetPath The target path (with or without file name)
+ @param shouldResume If YES, tries to resume a partial download if found.
+ @return A new download request operation
+ */
+- (id)initWithRequest:(NSURLRequest *)urlRequest fileIdentifier:(NSString *)fileIdentifier targetPath:(NSString *)targetPath shouldResume:(BOOL)shouldResume;
+
 /** 
  Deletes the temporary file.
  

--- a/AFDownloadRequestOperation.m
+++ b/AFDownloadRequestOperation.m
@@ -42,6 +42,7 @@ typedef void (^AFURLConnectionProgressiveOperationProgressBlock)(AFDownloadReque
     id _responseObject;
 }
 @property (nonatomic, strong) NSString *tempPath;
+@property (nonatomic, strong) NSString *fileIdentifier;
 @property (assign) long long totalContentLength;
 @property (nonatomic, assign) long long totalBytesReadPerDownload;
 @property (assign) long long offsetContentLength;
@@ -62,9 +63,14 @@ typedef void (^AFURLConnectionProgressiveOperationProgressBlock)(AFDownloadReque
 }
 
 - (id)initWithRequest:(NSURLRequest *)urlRequest targetPath:(NSString *)targetPath shouldResume:(BOOL)shouldResume {
-    if ((self = [super initWithRequest:urlRequest])) {
+    return [self initWithRequest:urlRequest fileIdentifier:nil targetPath:targetPath shouldResume:shouldResume];
+}
+
+- (id)initWithRequest:(NSURLRequest *)urlRequest fileIdentifier:(NSString *)fileIdentifier targetPath:(NSString *)targetPath shouldResume:(BOOL)shouldResume {    if ((self = [super initWithRequest:urlRequest])) {
         NSParameterAssert(targetPath != nil && urlRequest != nil);
         _shouldResume = shouldResume;
+
+        self.fileIdentifier = fileIdentifier;
 
         // Ee assume that at least the directory has to exist on the targetPath
         BOOL isDirectory;
@@ -137,7 +143,10 @@ typedef void (^AFURLConnectionProgressiveOperationProgressBlock)(AFDownloadReque
 
 - (NSString *)tempPath {
     NSString *tempPath = nil;
-    if (self.targetPath) {
+    if (self.fileIdentifier) {
+        tempPath = [[[self class] cacheFolder] stringByAppendingPathComponent:self.fileIdentifier];
+    }
+    else if (self.targetPath) {
         NSString *md5URLString = [[self class] md5StringForString:self.targetPath];
         tempPath = [[[self class] cacheFolder] stringByAppendingPathComponent:md5URLString];
     }


### PR DESCRIPTION
Context: iOS seems to generate a random a container path for the application (at
least when debugging).
With this new method is possible to indicate which temporary filename
we wish and thus remove the problems that arise with the random paths
(e.g., the resume not working).