### PR TITLE
Change AFNetworking import to allow framework build

### DIFF
--- a/AFDownloadRequestOperation.h
+++ b/AFDownloadRequestOperation.h
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import "AFHTTPRequestOperation.h"
+#import <AFNetworking/AFNetworking.h>
 
 #define kAFNetworkingIncompleteDownloadFolderName @"Incomplete"
 

--- a/AFDownloadRequestOperation.podspec
+++ b/AFDownloadRequestOperation.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name           = 'AFDownloadRequestOperation'
-  s.version        = '2.0.2'
+  s.version        = '2.0.3'
   s.summary        = "A progressive download operation for AFNetworking."
   s.homepage       = "https://github.com/steipete/AFDownloadRequestOperation"
   s.author         = { 'Peter Steinberger' => 'steipete@gmail.com' }
@@ -10,6 +10,6 @@ Pod::Spec.new do |s|
   s.requires_arc   = true
   s.source_files   = '*.{h,m}'
   s.license        = 'MIT'
-  s.dependency 'AFNetworking', '~> 2.0'
+  s.dependency 'AFNetworking/NSURLConnection', '~> 2.0'
 end
 

--- a/AFDownloadRequestOperation.podspec
+++ b/AFDownloadRequestOperation.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name           = 'AFDownloadRequestOperation'
-  s.version        = '2.0.1'
+  s.version        = '2.0.2'
   s.summary        = "A progressive download operation for AFNetworking."
   s.homepage       = "https://github.com/steipete/AFDownloadRequestOperation"
   s.author         = { 'Peter Steinberger' => 'steipete@gmail.com' }
-  s.source         = { :git => 'https://github.com/steipete/AFDownloadRequestOperation.git', :tag => s.version.to_s }
+  s.source         = { :git => 'https://github.com/sammcewan/AFDownloadRequestOperation.git', :tag => s.version.to_s }
   s.ios.deployment_target = '6.0'
   s.osx.deployment_target = '10.8'
   s.requires_arc   = true


### PR DESCRIPTION
Changing import to allow AFDownloadRequestOperation to be built as a framework.
